### PR TITLE
remove direct call to methods::`slot<-`

### DIFF
--- a/R/replaceSlots.R
+++ b/R/replaceSlots.R
@@ -12,7 +12,8 @@
 ### we have one).
 ###
 
-unsafe_replaceSlots <- function(object, ..., .slotList = list()) {
+unsafe_replaceSlots <- function(object, ..., .slotList = list()) 
+{
   valid_argnames <- slotNames(object)
   args <- extraArgsAsList(valid_argnames, ...)
   listUpdate <- function(object, l) {
@@ -26,6 +27,7 @@ unsafe_replaceSlots <- function(object, ..., .slotList = list()) {
       slot(object, nm, check=FALSE) <- l[[nm]]
     }
     object
+  }
 }
 
 ### replaceSlots() is essentially a more efficient initialize(), especially

--- a/R/replaceSlots.R
+++ b/R/replaceSlots.R
@@ -12,22 +12,22 @@
 ### we have one).
 ###
 
-unsafe_replaceSlots <- function(object, ..., .slotList = list()) 
-{
-  valid_argnames <- slotNames(object)
-  args <- extraArgsAsList(valid_argnames, ...)
-  listUpdate <- function(object, l) {
-    for (nm in names(l)) {
-      ## Too risky! identical() is not reliable enough e.g. with objects
-      ## that contain external pointers. For example, DNAStringSet("A") and
-      ## DNAStringSet("T") are considered to be identical! identical() needs
-      ## to be fixed first.
-      ##if (identical(slot(object, nm), l[[nm]]))
-      ##  next
-      slot(object, nm, check=FALSE) <- l[[nm]]
+unsafe_replaceSlots <- function(object, ..., .slotList = list()) {
+    valid_argnames <- slotNames(object)
+    args <- extraArgsAsList(valid_argnames, ...)
+    listUpdate <- function(object, l) {
+        for (nm in names(l)) {
+            ## Too risky! identical() is not reliable enough e.g. with objects
+            ## that contain external pointers. For example, DNAStringSet("A") and
+            ## DNAStringSet("T") are considered to be identical! identical() needs
+            ## to be fixed first.
+            ##if (identical(slot(object, nm), l[[nm]]))
+            ##  next
+            slot(object, nm, check=FALSE) <- l[[nm]]
+        }
+        object
     }
-    object
-  }
+    listUpdate(listUpdate(object, args), .slotList)
 }
 
 ### replaceSlots() is essentially a more efficient initialize(), especially

--- a/R/replaceSlots.R
+++ b/R/replaceSlots.R
@@ -12,44 +12,18 @@
 ### we have one).
 ###
 
-unsafe_replaceSlots <- function(object, ..., .slotList=list())
-{
-    slots <- c(list(...), .slotList)
-    slots_names <- names(slots)
-    ## This is too slow. See further down for a much faster way to check
-    ## that the supplied slots exist.
-    #invalid_idx <- which(!(slots_names %in% slotNames(object)))
-    #if (length(invalid_idx) != 0L) {
-    #    in1string <- paste0(slots_names[invalid_idx], collapse=", ")
-    #    stop(wmsg("invalid slot(s) for ", class(object), " instance: ",
-    #              in1string))
-    #}
-    first_time <- TRUE
-    for (i in seq_along(slots)) {
-        slot_name <- slots_names[[i]]
-        if (slot_name == "mcols")
-            slot_name <- "elementMetadata"
-        ## Even if we won't make any use of 'old_slot_val', this is a very
-        ## efficient way to check that the supplied slot exists.
-        ## We need to check this because the slot setter won't raise an error
-        ## in case of invalid slot name when used with 'check=FALSE'. It will
-        ## silently be a no-op!
-        old_slot_val <- slot(object, slot_name) # just a 
-        slot_val <- slots[[i]]
-        ## Too risky! identical() is not reliable enough e.g. with objects
-        ## that contain external pointers. For example, DNAStringSet("A")
-        ## and DNAStringSet("T") are considered to be identical! identical()
-        ## would first need to be fixed.
-        #if (identical(old_slot_val, slot_val))
-        #    next
-        if (first_time) {
-            ## Triggers a copy.
-            slot(object, slot_name, check=FALSE) <- slot_val
-            first_time <- FALSE
-        } else {
-            ## In-place modification (i.e. no copy).
-            `slot<-`(object, slot_name, check=FALSE, slot_val)
-        }
+unsafe_replaceSlots <- function(object, ..., .slotList = list()) {
+  valid_argnames <- slotNames(object)
+  args <- extraArgsAsList(valid_argnames, ...)
+  listUpdate <- function(object, l) {
+    for (nm in names(l)) {
+      ## Too risky! identical() is not reliable enough e.g. with objects
+      ## that contain external pointers. For example, DNAStringSet("A") and
+      ## DNAStringSet("T") are considered to be identical! identical() needs
+      ## to be fixed first.
+      ##if (identical(slot(object, nm), l[[nm]]))
+      ##  next
+      slot(object, nm, check=FALSE) <- l[[nm]]
     }
     object
 }


### PR DESCRIPTION
`slot<-` from methods package is a wrapper around R_do_slot_assign
function from GNU R. This function is being called with the assumption
that assignments to slots are performed in-place and thus no new copies
are being made. This is not true, as R_do_slot_assign will make new
copies if the named bit is set (object is shared), see this line in GNU
R C code:
https://github.com/wch/r-source/blob/d00ce14c27db627d8644cce8551b792362cc46bf/src/main/attrib.c#L1784

Therefore this additional steps will not give any improvements over call
to slot()<- and depends on implementation details, changes to which
could break this function and packages dependending on this (eg
SummarizedExperiment rbind function).